### PR TITLE
Automatically tag Instructor/Student topics with resolution status upon post

### DIFF
--- a/src/cli/setup.js
+++ b/src/cli/setup.js
@@ -27,7 +27,6 @@ async function setup(initConfig) {
 		configFile = path.resolve(paths.baseDir, config);
 	}
 
-	console.log('===000===000=== SETTING UP');
 	const data = await install.setup();
 
 	prestart.loadConfig(configFile);

--- a/src/install.js
+++ b/src/install.js
@@ -424,7 +424,6 @@ async function createGlobalModeratorsGroup() {
 }
 
 async function createInstructorsGroup() {
-	console.log('===000===000===CREATING INSTRUCTORS');
 	const groups = require('./groups');
 	const exists = await groups.exists('Instructors');
 	if (exists) {
@@ -443,6 +442,24 @@ async function createInstructorsGroup() {
 	await groups.show('Instructors');
 }
 
+async function createStudentsGroup() {
+	const groups = require('./groups');
+	const exists = await groups.exists('Students');
+	if (exists) {
+		winston.info('Students group found, skipping creation!');
+	} else {
+		await groups.create({
+			name: 'Students',
+			userTitle: 'Student',
+			userTitleEnabled: 0,
+			hidden: 0,
+			private: 1,
+			disableJoinRequests: 1,
+		});
+	}
+	await groups.show('Students');
+}
+
 async function giveGlobalPrivileges() {
 	const privileges = require('./privileges');
 	const defaultPrivileges = [
@@ -451,8 +468,8 @@ async function giveGlobalPrivileges() {
 		'groups:local:login',
 	];
 	await privileges.global.give(defaultPrivileges, 'registered-users');
+	await privileges.global.give(defaultPrivileges, 'Students');
 	await privileges.global.give(defaultPrivileges.concat(['groups:view:users:info']), 'Instructors');
-	console.log('===000===000===GAVE INSTRUCTORS PERMS');
 	await privileges.global.give(defaultPrivileges.concat([
 		'groups:ban', 'groups:upload:post:file']), 'Global Moderators');
 	await privileges.global.give(['groups:view:users', 'groups:view:tags', 'groups:view:groups'], 'guests');
@@ -609,6 +626,7 @@ install.setup = async function () {
 		const adminInfo = await createAdministrator();
 		await createGlobalModeratorsGroup();
 		await createInstructorsGroup();
+		await createStudentsGroup();
 		await giveGlobalPrivileges();
 		await createMenuItems();
 		await createWelcomePost();

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -19,6 +19,14 @@ privsUsers.isGlobalModerator = async function (uid) {
 	return await isGroupMember(uid, 'Global Moderators');
 };
 
+privsUsers.isInstructor = async function (uid) {
+	return await isGroupMember(uid, 'Instructors');
+};
+
+privsUsers.isStudent = async function (uid) {
+	return await isGroupMember(uid, 'Students');
+};
+
 async function isGroupMember(uid, groupName) {
 	return await groups[Array.isArray(uid) ? 'isMembers' : 'isMember'](uid, groupName);
 }

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -161,6 +161,14 @@ User.isGlobalModerator = async function (uid) {
 	return await privileges.users.isGlobalModerator(uid);
 };
 
+User.isInstructor = async function (uid) {
+	return await privileges.users.isInstructor(uid);
+};
+
+User.isStudent = async function (uid) {
+	return await privileges.users.isStudent(uid);
+};
+
 User.getPrivileges = async function (uid) {
 	return await utils.promiseParallel({
 		isAdmin: User.isAdministrator(uid),


### PR DESCRIPTION
**Context**
Resolves issues #30 and #27 and addresses #24. Addresses user stories for resolved/unresolved posts and instructor role indicator.

**Description**
Created Students group on installation. Dependent on Instructors group created in `add-role-groups` branch. Add membership checks for Instructors/Students groups. Upon topic creation, tag with "instructor-post"/"unresolved" tags for Instructors/Students.

**Codebase Changes**
- `src/install.js`: Function `createStudentsGroup` initializes Students group and privileges are given in the same file.
- `src/privileges/users.js`: Functions `isInstructor` and `isStudent` are group membership checks for users.
- `src/user/index.js`: Exports the membership functions as part of user.
- `src/topics/create.js`: Modifies `Topics.post` to automatically add 'unresolved' and 'instructor-post' tags to topics when they are created by users in the 'Students' and 'Instructors' groups respectively.

**Additional Information**
Ran lint and test and tested using the following steps.

User testing:
1. Add user to Instructors group
2. Post a new topic
3. `instructor-post` tag should be automatically added  
<!-- -->
1. Add user to Students group
2. Post a new topic
3. `unresolved` tag should be automatically added

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/22271434-b45f-4836-b5c4-76106b3eb1c7" />
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/79884a3c-8ce3-40d6-9c02-c6d6687fc87f" />