### PR TITLE
Automatic refresh of Student topic tags to display topic resolution upon Instructor reply

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -31,6 +31,8 @@ define('forum/topic/events', [
 
 		'event:topic_moved': onTopicMoved,
 
+		'event:topic_resolved': onTopicResolved,
+
 		'event:post_edited': onPostEdited,
 		'event:post_purged': onPostPurged,
 
@@ -100,7 +102,16 @@ define('forum/topic/events', [
 		}
 	}
 
+	function onTopicResolved(data) {
+		if (data.topic && data.topic.tags){
+			require(['forum/topic/tag'], function (tag) {
+				tag.updateTopicTags([data.topic]);
+			});
+		}
+	}
+
 	function onPostEdited(data) {
+		console.trace();
 		if (!data || !data.post || parseInt(data.post.tid, 10) !== parseInt(ajaxify.data.tid, 10)) {
 			return;
 		}

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -103,7 +103,7 @@ define('forum/topic/events', [
 	}
 
 	function onTopicResolved(data) {
-		if (data.topic && data.topic.tags){
+		if (data.topic && data.topic.tags) {
 			require(['forum/topic/tag'], function (tag) {
 				tag.updateTopicTags([data.topic]);
 			});

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -178,9 +178,10 @@ module.exports = function (Topics) {
 		const { tid } = data;
 		const { uid } = data;
 
-		const [topicData, isAdmin] = await Promise.all([
+		const [topicData, isAdmin, isInstructor] = await Promise.all([
 			Topics.getTopicData(tid),
 			privileges.users.isAdministrator(uid),
+			privileges.users.isInstructor(uid),
 		]);
 
 		await canReply(data, topicData);
@@ -201,6 +202,11 @@ module.exports = function (Topics) {
 		// For replies to scheduled topics, don't have a timestamp older than topic's itself
 		if (topicData.scheduled) {
 			data.timestamp = topicData.lastposttime + 1;
+		}
+
+		if (isInstructor) {
+			console.log('add resolved');
+			Topics.resolveTopics([tid]);
 		}
 
 		data.ip = data.req ? data.req.ip : null;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -14,6 +14,7 @@ const posts = require('../posts');
 const privileges = require('../privileges');
 const categories = require('../categories');
 const translator = require('../translator');
+const websockets = require('../socket.io');
 
 module.exports = function (Topics) {
 	Topics.create = async function (data) {
@@ -252,7 +253,7 @@ module.exports = function (Topics) {
 		// Refresh tags
 		tags = await Topics.getTopicTagsObjects(tid);
 		data.tags = tags;
-		websockets.in(`topic_${tid}`).emit('event:topic_resolved', {topic: data});
+		websockets.in(`topic_${tid}`).emit('event:topic_resolved', { topic: data });
 	}
 
 	async function onNewPost(postData, data) {

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -410,17 +410,6 @@ module.exports = function (Topics) {
 		await Topics.updateCategoryTagsCount(_.uniq(topicData.map(t => t.cid)), tags);
 	};
 
-	Topics.resolveTopics = async function (tid, tags) {
-		const topicTags = tags.map(tagItem => tagItem.value);
-		if (!topicTags.includes('unresolved')) {
-			return;
-		}
-		topicTags.splice(topicTags.indexOf('unresolved'), 1);
-		topicTags.push('resolved');
-		await Topics.updateTopicTags(tid, topicTags);
-		// websockets.in(`topic_${tid}`).emit('event:topic_resolved', editResult);
-	};
-
 	Topics.updateTopicTags = async function (tid, tags) {
 		await Topics.deleteTopicTags(tid);
 		const cid = await Topics.getTopicField(tid, 'cid');

--- a/test/topics.js
+++ b/test/topics.js
@@ -29,6 +29,8 @@ describe('Topic\'s', () => {
 	let topic;
 	let categoryObj;
 	let adminUid;
+	let instructorUid;
+	let studentUid;
 	let adminJar;
 	let csrf_token;
 	let fooUid;
@@ -40,6 +42,11 @@ describe('Topic\'s', () => {
 		const adminLogin = await helpers.loginUser('admin', '123456');
 		adminJar = adminLogin.jar;
 		csrf_token = adminLogin.csrf_token;
+
+		instructorUid = await User.create({ username: 'prof' });
+		await groups.join('Instructors', instructorUid);
+		studentUid = await User.create({ username: 'student' });
+		await groups.join('Students', studentUid);
 
 		categoryObj = await categories.create({
 			name: 'Test Category',
@@ -1674,6 +1681,14 @@ describe('Topic\'s', () => {
 			categoryTags = await topics.getCategoryTags(cid, 0, -1);
 			assert.deepStrictEqual(tags.sort(), ['tag2', 'tag4', 'tag6']);
 			assert.deepStrictEqual(categoryTags.sort(), ['tag2', 'tag4', 'tag6']);
+		});
+
+		it('should resolve topic', async () => {
+			const t = await topics.post({ uid: studentUid, tags: [], title: 'topic title 1', content: 'topic 1 content', cid: topic.categoryId });
+			const { tid } = t.topicData;
+			await topics.reply({ uid: instructorUid, content: 'reply 1 content', tid: tid });
+			const tags = await topics.getTopicTags(tid);
+			assert.deepStrictEqual(tags.sort(), ['resolved']);
 		});
 
 		it('should respect minTags', async () => {


### PR DESCRIPTION
**Context**
Resolves issues #51 and #52. Addresses user stories for resolved/unresolved posts and instructor role indicator.

**Description**
Added new functions to trigger an automatic refresh of the topic tag when a Student topic is resolved by an Instructor reply.

**Codebase Changes**
- `src/topics/create.js`: In `Topics.reply` calls newly added function `resolveTopic` which calls `Topics.updateTopicTags` in `src/topics/tags.js` to swap the `unresolved` tag for a `resolved` tag. Then it triggers a websocket event `event:topic_resolved` which activates a new listener in `public/src/client/topic/events.js`
- `public/src/client/topic/events.js`: Added function `onTopicResolved` which calls `Tag.updateTopicTags` in `public/src/client/topic/tag.js` which updates the topic tags on the user end.
- Added tests to `test/topics.js`

**Additional Information**
Test added to `test/topics.js` to address resolving of Student post.
Ran lint and test and tested using the following steps.

**User testing:**
1. Student posts a new topic
2. `unresolved` tag should be automatically added
3. Instructor replies to the topic
4. `resolved` tag should be automatically added and the `unresolved` tag should be automatically removed without requiring a manual page refresh

Coverage after all topic resolution feature implementation:
![image](https://github.com/user-attachments/assets/81835703-6baf-49c7-a27c-28bdaf9b4297)

Coverage after test added to test suite:
![image](https://github.com/user-attachments/assets/a723aae2-2cb3-4063-a598-9b6491648d93)

