### PR TITLE
Static Tool #2: CodeSpell -- Fixed spelling errors in comments with codespell

### DIFF
--- a/src/upgrades/1.10.2/upgrade_bans_to_hashes.js
+++ b/src/upgrades/1.10.2/upgrade_bans_to_hashes.js
@@ -20,7 +20,7 @@ module.exports = {
 					db.getObjectFields(`user:${uid}`, ['banned', 'banned:expire', 'joindate', 'lastposttime', 'lastonline']),
 				]);
 
-				// has no history, but is banned, create plain object with just uid and timestmap
+				// has no history, but is banned, create plain object with just uid and timestamp
 				if (!bans.length && parseInt(userData.banned, 10)) {
 					const banTimestamp = (
 						userData.lastonline ||

--- a/src/upgrades/1.19.3/rename_post_upload_hashes.js
+++ b/src/upgrades/1.19.3/rename_post_upload_hashes.js
@@ -41,7 +41,7 @@ module.exports = {
 				const hashes = uploads.map(upload => md5(upload.value));
 				const newHashes = uploads.map(upload => md5(`files/${upload.value}`));
 
-				// cant use db.rename since `fix_user_uploads_zset.js` upgrade script already creates
+				// can't use db.rename since `fix_user_uploads_zset.js` upgrade script already creates
 				// `upload:md5(upload.value) hash, trying to rename to existing key results in dupe error
 				const oldData = await db.getObjects(hashes.map(hash => `upload:${hash}`));
 				const bulkSet = [];

--- a/src/upgrades/2.8.7/fix-email-sorted-sets.js
+++ b/src/upgrades/2.8.7/fix-email-sorted-sets.js
@@ -25,7 +25,7 @@ module.exports = {
 					return;
 				}
 
-				// user has email but doesn't match whats stored in user hash, gh#11259
+				// user has email but doesn't match what's stored in user hash, gh#11259
 				if (userData.email && userData.email.toLowerCase() !== email.toLowerCase()) {
 					bulkRemove.push(['email:uid', email]);
 					bulkRemove.push(['email:sorted', `${email.toLowerCase()}:${uid}`]);


### PR DESCRIPTION
**Context**
CodeSpell fix common misspellings in text files. It's designed primarily for checking misspelled words in source code (backslash escapes are skipped), but it can be used with other files as well. It does not check for word membership in a complete dictionary, but instead looks for a set of common misspellings. Therefore it should catch errors like "adn", but it will not catch "adnasdfasdf". This also means it shouldn't generate false-positives when you use a niche term it doesn't know about.

Since all syntax of the code is usually tested but the comments often contained mistake, we thought this would be a nice addition since there isn't spelling checks in the actual IDE itself.

**Description**
Integrating CodeSpell was very simple, instead of changing file dependencies, we only needed to run the command to install it locally:

`pip install codespell`

To see errors, we ran: `codespell`, or specifically on a directory or file

**Proof that it ran locally & gave meaningful output**
<img width="703" alt="Screenshot 2025-03-13 at 22 42 05" src="https://github.com/user-attachments/assets/afb74261-5f9d-43d9-8852-8a5dbbfdd9ef" />

Note: since it checks all files and is mostly meant for text files, it gave false negatives for a lot of the code files. We just have to filter them as we go through.